### PR TITLE
refactor: clean up project dependencies and organize dev tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ checks.sh
 alembic*
 .log
 .parquet
+.mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,34 +5,43 @@ description = "Experimenter Analytics Tools"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mypy>=1.14.1",
+    # Core
     "pydantic>=2.10.6",
-    "pytest>=8.3.4",
-    "ruff>=0.9.3",
-    "scipy>=1.15.1",
-    "snowflake-connector-python>=3.13.2",
-    "statsmodels>=0.14.4",
-    "streamlit>=1.48.0",
+    "pydantic-settings>=2.4.0",
+    "streamlit>=1.49.0",
     "sqlalchemy[asyncio]>=2.0.38",
-    "python-dotenv>=1.0.1",
-    "pyyaml>=6.0.2",
-    "loguru>=0.7.3",
-    "pydantic-ai-slim[duckduckgo,tavily]>=0.7.0",
-    "chromadb>=1.0.5",
-    "pydantic-ai>=0.7.0",
+    "aiosqlite>=0.21.0",
+    "jinja2>=3.1.4",
+    
+    # Data
+    "scipy>=1.15.1",
+    "statsmodels>=0.14.4",
     "plotly>=6.0.1",
-    "google-cloud>=0.34.0",
+    "tabulate>=0.9.0",
+    
+    # Connectors
+    "snowflake-connector-python>=3.13.2",
     "google-cloud-bigquery[bqstorage,pandas]>=3.31.0",
     "db-dtypes>=1.4.2",
     "pyarrow<19",
+    
+    # LLM
+    "pydantic-ai>=0.7.0",
+    "pydantic-ai-slim[duckduckgo,tavily]>=0.7.0",
+    "chromadb>=1.0.5",
     "fastapi[standard]>=0.115.9",
-    "requests>=2.32.3",
-    "aiosqlite>=0.21.0",
-    "tabulate>=0.9.0",
-    "pydantic-settings>=2.4.0",
-    "jinja2>=3.1.4",
+    
+    # Utilities
+    "pyyaml>=6.0.2",
+    "logfire[fastapi,httpx,requests,sqlalchemy]>=4.3.3",
+]
+
+[dependency-groups]
+dev = [
+    "mypy>=1.14.1",
+    "ruff>=0.9.3",
+    "pytest>=8.3.4",
     "pytest-asyncio>=1.0.0",
-    "logfire[fastapi,httpx,pydantic,pydantic-ai,requests,sqlalchemy]>=4.3.3",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -610,31 +610,23 @@ wheels = [
 
 [[package]]
 name = "expanto"
-version = "0.1.0"
+version = "0.1.0a1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "chromadb" },
     { name = "db-dtypes" },
     { name = "fastapi", extra = ["standard"] },
-    { name = "google-cloud" },
     { name = "google-cloud-bigquery", extra = ["bqstorage", "pandas"] },
     { name = "jinja2" },
     { name = "logfire", extra = ["fastapi", "httpx", "requests", "sqlalchemy"] },
-    { name = "loguru" },
-    { name = "mypy" },
     { name = "plotly" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "pydantic-ai-slim", extra = ["duckduckgo", "tavily"] },
     { name = "pydantic-settings" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "requests" },
-    { name = "ruff" },
     { name = "scipy" },
     { name = "snowflake-connector-python" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -643,36 +635,44 @@ dependencies = [
     { name = "tabulate" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "chromadb", specifier = ">=1.0.5" },
     { name = "db-dtypes", specifier = ">=1.4.2" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.9" },
-    { name = "google-cloud", specifier = ">=0.34.0" },
     { name = "google-cloud-bigquery", extras = ["bqstorage", "pandas"], specifier = ">=3.31.0" },
     { name = "jinja2", specifier = ">=3.1.4" },
-    { name = "logfire", extras = ["fastapi", "httpx", "pydantic", "pydantic-ai", "requests", "sqlalchemy"], specifier = ">=4.3.3" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mypy", specifier = ">=1.14.1" },
+    { name = "logfire", extras = ["fastapi", "httpx", "requests", "sqlalchemy"], specifier = ">=4.3.3" },
     { name = "plotly", specifier = ">=6.0.1" },
     { name = "pyarrow", specifier = "<19" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-ai", specifier = ">=0.7.0" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo", "tavily"], specifier = ">=0.7.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-asyncio", specifier = ">=1.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "requests", specifier = ">=2.32.3" },
-    { name = "ruff", specifier = ">=0.9.3" },
     { name = "scipy", specifier = ">=1.15.1" },
     { name = "snowflake-connector-python", specifier = ">=3.13.2" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.38" },
     { name = "statsmodels", specifier = ">=0.14.4" },
-    { name = "streamlit", specifier = ">=1.48.0" },
+    { name = "streamlit", specifier = ">=1.49.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.14.1" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "ruff", specifier = ">=0.9.3" },
 ]
 
 [[package]]
@@ -901,15 +901,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/87/e10bf24f7bcffc1421b84d6f9c3377c30ec305d082cd737ddaa6d8f77f7c/google_auth_oauthlib-1.2.2.tar.gz", hash = "sha256:11046fb8d3348b296302dd939ace8af0a724042e8029c1b872d87fabc9f41684", size = 20955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/84/40ee070be95771acd2f4418981edb834979424565c3eec3cd88b6aa09d24/google_auth_oauthlib-1.2.2-py3-none-any.whl", hash = "sha256:fd619506f4b3908b5df17b65f39ca8d66ea56986e5472eb5978fd8f3786f00a2", size = 19072 },
-]
-
-[[package]]
-name = "google-cloud"
-version = "0.34.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/0e/8bf108fa9e3e036fe37a86598f1315e7b8de90b89012fd65704dc30ac6ad/google-cloud-0.34.0.tar.gz", hash = "sha256:01430187cf56df10a9ba775dd547393185d4b40741db0ea5889301f8e7a9d5d3", size = 2514 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/b1/7c54d1950e7808df06642274e677dbcedba57f75307adf2e5ad8d39e5e0e/google_cloud-0.34.0-py2.py3-none-any.whl", hash = "sha256:fb1ab7b0548fe44b3d538041f0a374505b7f990d448a935ea36649c5ccab5acf", size = 1839 },
 ]
 
 [[package]]
@@ -1454,19 +1445,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d1/3a/d44e4a8e7906821a444fdfd64428a858b26fe222d1c4ed74dcd4d25556f2/logfire_api-3.21.1.tar.gz", hash = "sha256:3af7818c1d831da027667d2eeff8f8993d793eb5063e03d817b8cda90ddca1a8", size = 49362 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/fe/36c8b8b66834d568d28a87de1cab4cb163f1358ac58dd8a0145db12f04e2/logfire_api-3.21.1-py3-none-any.whl", hash = "sha256:c85888e8f4df806b389c9f851ee5db044e2451dd8813ba0dd6a6c2279a8b8edb", size = 82482 },
-]
-
-[[package]]
-name = "loguru"
-version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595 },
 ]
 
 [[package]]
@@ -3324,7 +3302,7 @@ wheels = [
 
 [[package]]
 name = "streamlit"
-version = "1.48.0"
+version = "1.49.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altair" },
@@ -3346,9 +3324,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog", marker = "sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/9f/373ba8d9f1190cce0a1b04cd9e77fd933c8238506aa1e3440eefabfc16f3/streamlit-1.48.0.tar.gz", hash = "sha256:64da4819f4b897c8d1e9eb6396f4618b2eb5029d25af61472422d4eb0688bb75", size = 9526680 }
+sdist = { url = "https://files.pythonhosted.org/packages/24/17/c8024e4ef311dc7833987c603a7d0ebe82f8aa352aaca53b27be3f6b7f01/streamlit-1.49.1.tar.gz", hash = "sha256:6f213f1e43f035143a56f58ad50068d8a09482f0a2dad1050d7e7e99a9689818", size = 9640116 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/92/095c67f3d17b6116c2b1882bb5ac719939154ee5bc7e7610ee325159a101/streamlit-1.48.0-py3-none-any.whl", hash = "sha256:0f2bc697a1a4d2199384d8bb3966aa0b25904c9345e6d6ad6fbb69bd284c03a2", size = 9928889 },
+    { url = "https://files.pythonhosted.org/packages/85/9e/146cdef515ad07e56c3aa942d087562498592d441aa3bae845ef0cd8fca3/streamlit-1.49.1-py3-none-any.whl", hash = "sha256:ad7b6d0dc35db168587acf96f80378249467fc057ed739a41c511f6bf5aa173b", size = 10044388 },
 ]
 
 [[package]]
@@ -3763,15 +3741,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
-]
-
-[[package]]
-name = "win32-setctime"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Remove unused packages (python-dotenv, google-cloud, loguru)
- Move dev tools (mypy, ruff, pytest) to [dependency-groups]
- Organize dependencies by category with clear comments
- Ensure uv sync installs only runtime packages
- Ensure uv sync --group dev includes development tools

Closes #2 