### PR TITLE
Refactor test configuration and fixtures to reduce duplication

### DIFF
--- a/tests/assets/configs.py
+++ b/tests/assets/configs.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+dir_fake_metrics = Path(__file__).parent / "metrics"
+dir_fake_query = Path(__file__).parent
+
+
+fake_configs_dict = {
+    "metrics": {"dir": str(dir_fake_metrics)},
+    "queries": {
+        "dir": str(dir_fake_query),
+        "scenarios": {
+            "base": "query.j2",
+            "base2": "base2",
+        },
+    },
+    "precompute_db": {"name": "snowflake"},
+    "assistant": {
+        "provider": "super_druper_provider",
+        "models": {
+            "fast": "Q",
+            "agentic": "Q",
+            "tool_thinker": "Q",
+        },
+        "service": {
+            "url": "http://127.0.0.1:8000",
+            "timeout_seconds": 600,
+            "enable_streaming": True,
+            "auto_scroll": True,
+        },
+    },
+    "logfire": {"send_to_logfire": False},
+}
+
+fake_secrets_dict = {
+    "internal_db": {
+        "engine_str": "to_replace",
+        "async_engine_str": "fake",
+        "connect_args": {},
+    },
+    "bigquery": {
+        "file_path": "/fake/path.json",
+        "project_name": "proj",
+        "connection_type": "service_account",
+    },
+    "snowflake": {
+        "account": "a",
+        "user": "u",
+        "password": "p",
+        "warehouse": "w",
+        "database": "d",
+        "schema": "s",
+    },
+    "api_keys": {
+        "PROVIDER_API_KEY": "TOGETHER_API_KEY",
+        "TAVILY_API_KEY": "TAVILY_API_KEY",
+        "LOGFIRE_TOKEN": "LOGFIRE_TOKEN",
+    },
+}

--- a/tests/assets/entities.py
+++ b/tests/assets/entities.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from datetime import UTC, timedelta
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from src.domain.models import CalculationJob, Experiment, Observation, Precompute
+from src.utils import DatetimeUtils
+
+UTC = UTC
+NOW = DatetimeUtils.utc_now()
+
+
+def insert_experiment(session: Session, **overrides: Any) -> Experiment:
+    exp = Experiment(
+        name=overrides.get("name", "Experiment"),
+        status=overrides.get("status", "planned"),
+        description=overrides.get("description"),
+        hypotheses=overrides.get("hypotheses"),
+        key_metrics=overrides.get("key_metrics", ["conversion_rate", "click_through_rate"]),
+        design=overrides.get("design"),
+        conclusion=overrides.get("conclusion"),
+        start_datetime=overrides.get("start_datetime", NOW - timedelta(days=30)),
+        end_datetime=overrides.get("end_datetime", NOW - timedelta(days=15)),
+        _created_at=overrides.get("_created_at", NOW - timedelta(days=45)),
+    )
+    session.add(exp)
+    session.commit()
+    session.refresh(exp)
+    return exp
+
+
+def insert_observation(session: Session, experiment_id: int, **overrides: Any) -> Observation:
+    obs = Observation(
+        experiment_id=experiment_id,
+        name=overrides.get("name", "Observation"),
+        db_experiment_name=overrides.get("db_experiment_name", "db_experiment"),
+        split_id=overrides.get("split_id", "user_id"),
+        calculation_scenario=overrides.get("calculation_scenario", "base"),
+        exposure_start_datetime=overrides.get("exposure_start_datetime", NOW - timedelta(days=30)),
+        exposure_end_datetime=overrides.get("exposure_end_datetime", NOW - timedelta(days=15)),
+        calc_start_datetime=overrides.get("calc_start_datetime", NOW - timedelta(days=30)),
+        calc_end_datetime=overrides.get("calc_end_datetime", NOW - timedelta(days=15)),
+        exposure_event=overrides.get("exposure_event", "page_view"),
+        audience_tables=overrides.get("audience_tables", ["active_users"]),
+        filters=overrides.get("filters", ["platform='web'", "country in ('USA', 'FR')"]),
+        custom_test_ids_query=overrides.get("custom_test_ids_query", "select * from test_ids"),
+        metric_tags=overrides.get("metric_tags", ["conversion"]),
+        metric_groups=overrides.get("metric_groups", ["engagement"]),
+        _created_at=overrides.get("_created_at", NOW - timedelta(days=44)),
+    )
+    session.add(obs)
+    session.commit()
+    session.refresh(obs)
+    return obs
+
+
+def insert_job(session: Session, observation_id: int, **overrides: Any) -> CalculationJob:
+    job = CalculationJob(
+        observation_id=observation_id,
+        query=overrides.get("query", "SELECT * FROM metrics WHERE experiment_id = 1"),
+        status=overrides.get("status", "completed"),
+        error_message=overrides.get("error_message"),
+        extra=overrides.get("extra", {"execution_time_ms": 1200, "bytes_read": 1024000}),
+        _created_at=overrides.get("_created_at", NOW - timedelta(days=44)),
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def insert_precompute(session: Session, job_id: int, **overrides: Any) -> Precompute:
+    pre = Precompute(
+        job_id=job_id,
+        group_name=overrides.get("group_name", "control"),
+        metric_name=overrides.get("metric_name", "conversion_rate"),
+        metric_display_name=overrides.get("metric_display_name", "Conversion Rate"),
+        metric_type=overrides.get("metric_type", "ratio"),
+        observation_cnt=overrides.get("observation_cnt", 1000),
+        metric_value=overrides.get("metric_value", 0.15),
+        numerator_avg=overrides.get("numerator_avg", 150),
+        denominator_avg=overrides.get("denominator_avg", 1000),
+        numerator_var=overrides.get("numerator_var", 127.5),
+        denominator_var=overrides.get("denominator_var", 0),
+        covariance=overrides.get("covariance", 0),
+        _created_at=overrides.get("_created_at", NOW - timedelta(days=44)),
+    )
+    session.add(pre)
+    session.commit()
+    session.refresh(pre)
+    return pre
+
+
+experiments_content = [
+    {
+        "name": "Button Color Test",
+        "status": "completed",
+        "description": "Testing the impact of button color on conversion rates",
+        "hypotheses": "Blue buttons will increase conversion rates by 10%",
+        "key_metrics": ["conversion_rate", "click_through_rate"],
+        "design": "A/B test with 50/50 split",
+        "conclusion": "Blue buttons increased conversion by 8%",
+        "start_datetime": DatetimeUtils.utc_now() - timedelta(days=30),
+        "end_datetime": DatetimeUtils.utc_now() - timedelta(days=15),
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=45),
+    },
+    {
+        "name": "Pricing Page Redesign",
+        "status": "running",
+        "description": "Testing new pricing page layout",
+        "hypotheses": "New layout will increase subscription rates",
+        "key_metrics": ["subscription_rate", "time_to_subscribe"],
+        "design": "A/B test with 70/30 split",
+        "start_datetime": DatetimeUtils.utc_now() - timedelta(days=10),
+        "end_datetime": DatetimeUtils.utc_now() - timedelta(days=10),
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=20),
+    },
+]
+
+
+# Observations content mirrors the data previously defined in tests/conftest.py
+observations_content = [
+    {
+        "name": "Main Conversion Analysis",
+        "db_experiment_name": "button_color_test",
+        "split_id": "user_id",
+        "calculation_scenario": "base",
+        "exposure_start_datetime": DatetimeUtils.utc_now() - timedelta(days=30),
+        "exposure_end_datetime": DatetimeUtils.utc_now() - timedelta(days=15),
+        "calc_start_datetime": DatetimeUtils.utc_now() - timedelta(days=30),
+        "calc_end_datetime": DatetimeUtils.utc_now() - timedelta(days=15),
+        "exposure_event": "page_view",
+        "audience_tables": ["active_users"],
+        "filters": ["platform='web'", "country in ('USA', 'FR')"],
+        "custom_test_ids_query": "select * from test_ids",
+        "metric_tags": ["conversion"],
+        "metric_groups": ["engagement"],
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=44),
+    },
+    {
+        "name": "Mobile Users Analysis",
+        "db_experiment_name": "button_color_test",
+        "split_id": "device_id",
+        "calculation_scenario": "base",
+        "exposure_start_datetime": DatetimeUtils.utc_now() - timedelta(days=30),
+        "exposure_end_datetime": DatetimeUtils.utc_now() - timedelta(days=15),
+        "calc_start_datetime": DatetimeUtils.utc_now() - timedelta(days=30),
+        "calc_end_datetime": DatetimeUtils.utc_now() - timedelta(days=15),
+        "exposure_event": "mobile_page_view",
+        "audience_tables": ["mobile_users"],
+        "filters": ["platform='mobile'"],
+        "custom_test_ids_query": "select * from test_ids",
+        "metric_tags": ["mobile"],
+        "metric_groups": ["engagement"],
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=45),
+    },
+    {
+        "name": "Pricing Page Analysis",
+        "db_experiment_name": "pricing_page_redesign",
+        "split_id": "user_id",
+        "calculation_scenario": "base",
+        "exposure_start_datetime": DatetimeUtils.utc_now() - timedelta(days=10),
+        "exposure_end_datetime": DatetimeUtils.utc_now() - timedelta(days=10),
+        "calc_start_datetime": DatetimeUtils.utc_now() - timedelta(days=10),
+        "calc_end_datetime": DatetimeUtils.utc_now() - timedelta(days=10),
+        "exposure_event": "pricing_page_view",
+        "audience_tables": ["potential_subscribers"],
+        "filters": ["has_visited_pricing=true"],
+        "custom_test_ids_query": "select * from test_ids",
+        "metric_tags": ["pricing"],
+        "metric_groups": ["conversion"],
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=46),
+    },
+]
+
+# Calculation jobs content mirrors the data previously defined in tests/conftest.py
+calculation_jobs_content = [
+    {
+        "query": "SELECT * FROM metrics WHERE experiment_id = 1",
+        "status": "completed",
+        "extra": {"execution_time_ms": 1200, "bytes_read": 1024000},
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=44),
+    },
+    {
+        "query": "SELECT * FROM metrics WHERE experiment_id = 1 AND date > '2024-01-01'",
+        "status": "failed",
+        "error_message": "Timeout error",
+        "extra": {"execution_time_ms": 30000, "error_code": "TIMEOUT"},
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=43),
+    },
+    {
+        "query": "SELECT * FROM mobile_metrics WHERE experiment_id = 1",
+        "status": "completed",
+        "extra": {"execution_time_ms": 800, "bytes_read": 512000, "cache_hit": True, "foo": "bar"},
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=44),
+    },
+    {
+        "query": "SELECT * FROM pricing_metrics WHERE experiment_id = 2",
+        "status": "running",
+        "extra": {"start_time": "2024-01-01T10:00:00Z"},
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=19),
+    },
+]
+
+# Precomputes content mirrors the data previously defined in tests/conftest.py
+precomputes_content = [
+    {
+        "group_name": "control",
+        "metric_name": "conversion_rate",
+        "metric_display_name": "Conversion Rate",
+        "metric_type": "ratio",
+        "observation_cnt": 1000,
+        "metric_value": 0.15,
+        "numerator_avg": 150,
+        "denominator_avg": 1000,
+        "numerator_var": 127.5,
+        "denominator_var": 0,
+        "covariance": 0,
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=44),
+    },
+    {
+        "group_name": "treatment",
+        "metric_name": "conversion_rate",
+        "metric_display_name": "Conversion Rate",
+        "metric_type": "ratio",
+        "observation_cnt": 1000,
+        "metric_value": 0.18,
+        "numerator_avg": 180,
+        "denominator_avg": 1000,
+        "numerator_var": 147.6,
+        "denominator_var": 0,
+        "covariance": 0,
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=44),
+    },
+    {
+        "group_name": "control",
+        "metric_name": "mobile_conversion_rate",
+        "metric_display_name": "Conversion Rate in Mobile",
+        "metric_type": "ratio",
+        "observation_cnt": 500,
+        "metric_value": 0.12,
+        "numerator_avg": 60,
+        "denominator_avg": 500,
+        "numerator_var": 52.8,
+        "denominator_var": 0,
+        "covariance": 0,
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=44),
+    },
+    {
+        "group_name": "control",
+        "metric_name": "subscription_rate",
+        "metric_display_name": "Subscription Rate",
+        "metric_type": "ratio",
+        "observation_cnt": 300,
+        "metric_value": 0.08,
+        "numerator_avg": 24,
+        "denominator_avg": 300,
+        "numerator_var": 22.08,
+        "denominator_var": 0,
+        "covariance": 0,
+        "_created_at": DatetimeUtils.utc_now() - timedelta(days=19),
+    },
+]

--- a/tests/assets/metrics/engagement_metrics.yaml
+++ b/tests/assets/metrics/engagement_metrics.yaml
@@ -1,0 +1,62 @@
+metric_group_name: 'User Behavior and Engagement Metrics'
+user_aggregations:
+  product_view_cnt: &product_view_cnt
+    alias: product_view_cnt
+    sql: COUNT(CASE event_name WHEN 'product_viewed' THEN event_name ELSE null END)
+
+  session_duration: &session_duration
+    alias: session_duration
+    sql: AVG(session_length)
+
+  product_click_flg: &product_click_flg
+    alias: product_click_flg
+    sql: MAX(CASE event_name WHEN 'product_clicked' THEN 1 ELSE 0 END)
+
+  product_purchase_flg: &product_purchase_flg
+    alias: product_purchase_flg
+    sql: MAX(CASE event_name WHEN 'product_purchased' THEN 1 ELSE 0 END)
+
+  product_view_flg: &product_view_flg
+    alias: product_view_flg
+    sql: MAX(CASE event_name WHEN 'product_viewed' THEN 1 ELSE 0 END)
+
+metrics:
+  - alias: click_through_rate
+    type: ratio
+    display_name: "CTR"
+    description: "Product clicks vs product views"
+    formula:
+      numerator: *product_click_flg
+      denominator: *product_view_cnt
+    owner: me
+    tags: ["engagement", "ui"]
+
+  - alias: conversion_rate
+    type: avg
+    display_name: "Conversion Rate"
+    description: "Product purchases vs product views"
+    formula:
+      numerator: *product_purchase_flg
+      denominator: null
+    owner: me
+    tags: ["conversion", "sales"]
+
+  - alias: avg_session_duration
+    type: avg
+    display_name: "Avg Session Duration"
+    description: "Average session length per user"
+    formula:
+      numerator: *session_duration
+      denominator: null
+    owner: me
+    tags: ["behavior", "time"]
+
+  - alias: users_who_click_product_ratio
+    type: proportion
+    display_name: "Users with Orders"
+    description: "some description"
+    formula:
+      numerator: *product_click_flg
+      denominator: null
+    owner: me
+    tags: null

--- a/tests/assets/metrics/order_metrics.yaml
+++ b/tests/assets/metrics/order_metrics.yaml
@@ -1,0 +1,20 @@
+metric_group_name: 'Order Metrics'
+user_aggregations:
+  product_purchase_cnt: &product_purchase_cnt
+    alias: product_purchase_cnt
+    sql: COUNT(CASE event_name WHEN 'product_purchased' THEN event_name ELSE null END)
+
+  product_revenue_sum: &product_revenue_sum
+    alias: product_revenue_sum
+    sql: SUM(CASE event_name WHEN 'product_purchased' THEN event_value ELSE 0 END)
+
+metrics:
+  - alias: avg_order_value
+    type: ratio
+    display_name: "Average Order Value"
+    description: "Sum of product purchase revenue divided by count"
+    formula:
+      numerator: *product_revenue_sum
+      denominator: *product_purchase_cnt
+    owner: me
+    tags: ["orders", "sales"]

--- a/tests/assets/query.j2
+++ b/tests/assets/query.j2
@@ -1,0 +1,47 @@
+SELECT
+{{ observation.split_id }} as split_id
+{% if purpose == 'planning' %} ,'planning' as purpose
+{% else %},'result' as purpose {% endif %}
+{% for user_formula in user_formula_list %}
+    , {{ user_formula.sql }} as {{ user_formula.alias }}{% endfor %}
+FROM {% if observation.segment %}{{ observation.segment }}
+{% else %} {{ observation.db_experiment_name }}
+{% endif %}
+WHERE 1 = 1
+AND exposure_timestamp BETWEEN '{{ observation.exposure_start_datetime }}' AND '{{ observation.exposure_end_datetime }}'
+AND event_timestamp BETWEEN '{{ observation.calc_start_datetime }}' AND '{{ observation.calc_end_datetime }}'
+{% if observation.filters %}
+    {% for filter in observation.filters %}
+        AND ({{ filter }}){% if not loop.last %} {% endif %}
+    {% endfor %}{% endif %}
+{% if observation.audience_tables %}
+    AND EXISTS (
+    SELECT 1 FROM {% for table in observation.audience_tables %}
+    {{ table }}{% if not loop.last %} UNION ALL {% endif %}
+{% endfor %}
+    ){% endif %}
+GROUP BY 1
+{% for metric in experiment_metrics_list %}
+    SELECT
+    GROUP_NAME as group_name
+    , '{{ metric.alias }}' as metric_name
+    , '{{ metric.type }}' as metric_type
+    , '{{ metric.display_name }}' as metric_display_name
+    , COUNT(distinct fake_template.{{ observation.split_id }}) as observations_cnt
+    , {{ metric.sql }} as metric_value
+    , AVG({{ metric.formula.numerator.alias }}) as numerator_avg
+    , VAR_SAMP({{ metric.formula.numerator.alias }}) as numerator_var
+    {% if metric.formula.denominator -%}
+        , AVG({{ metric.formula.denominator.alias }}) as denominator_avg
+        , VAR_SAMP({{ metric.formula.denominator.alias }}) as denominator_var
+        , COVAR_SAMP({{ metric.formula.denominator.alias }}, {{ metric.formula.numerator.alias }}) as covariance
+    {% else -%}
+        , CAST(null as float) as denominator_avg
+        , CAST(null as float) as denominator_var
+        , CAST(null as float) as covariance
+    {% endif -%}
+    FROM fake_template
+    GROUP BY group_name
+    {% if not loop.last %}
+        UNION ALL{% endif %}
+{% endfor %}

--- a/tests/assistant/conftest.py
+++ b/tests/assistant/conftest.py
@@ -1,0 +1,47 @@
+import pytest
+
+
+@pytest.fixture
+def patch_configs(
+    monkeypatch, disable_files_in_settings, fake_load_secrets_cfg, fake_load_expanto_cfg, engine, metrics
+):
+    """Patch configuration loading for UI testing."""
+    monkeypatch.setattr(
+        "assistant.app.Secrets",
+        lambda *a, **kw: fake_load_secrets_cfg,
+        raising=True,
+    )
+
+    # Same for Config()
+    monkeypatch.setattr(
+        "assistant.app.Config",
+        lambda *a, **kw: fake_load_expanto_cfg,
+        raising=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def docs_temp_dir(tmp_path_factory):
+    """Create temporary directory with mock documentation files."""
+    temp_dir = tmp_path_factory.mktemp("docs")
+    (temp_dir / "integration.md").write_text("Integration documentation. how to start with expanto")
+    (temp_dir / "queries.md").write_text("Queries documentation. how to create queries")
+    (temp_dir / "precompute.md").write_text("Precompute documentation. how to create precompute")
+    (temp_dir / "metrics.md").write_text("Metrics documentation. how to create metrics")
+    return temp_dir
+
+
+@pytest.fixture(scope="session")
+def root_dir(tmp_path_factory):
+    """Create temporary root directory structure for testing."""
+    temp_dir = tmp_path_factory.mktemp("root")
+    (temp_dir / "src").mkdir()
+    (temp_dir / ".expanto").mkdir()
+    (temp_dir / "src" / "agent").mkdir()
+    (temp_dir / "src" / "services").mkdir()
+    (temp_dir / "src" / ".env").write_text("ENV_VAR=!!!")
+    (temp_dir / "src" / "agent" / "vdb.py").write_text("This is a vdb code")
+    (temp_dir / "src" / "services" / "metric_register.py").write_text("This is a metric register code")
+    (temp_dir / "src" / "services" / "bigquery.py").write_text("This is a bigquery code")
+    (temp_dir / ".expanto" / "secrets.toml").write_text("SECRET_KEY=000111")
+    return temp_dir

--- a/tests/assistant/test_agents.py
+++ b/tests/assistant/test_agents.py
@@ -114,10 +114,10 @@ async def test_app_context_injected_into_prompt(injector_agent: Agent):
 
     # Verify the agent ran successfully and returned expected output
     assert result.output == "pong"
-    
+
     # Check that messages were captured
     assert len(messages) > 0
-    
+
     # Check that UserPromptPart contains the original message
     for msg in messages:
         if not isinstance(msg, ModelRequest):
@@ -190,7 +190,7 @@ async def test_agent_orchestrator_low_confidence_returns_follow_up_questions():
             # Create mock assistant_models with required attributes
             self.assistant_models = SimpleNamespace(
                 fast="test-router",
-                agentic="test-agentic", 
+                agentic="test-agentic",
                 tool_thinker="test-tool-thinker",
             )
 

--- a/tests/assistant/test_app.py
+++ b/tests/assistant/test_app.py
@@ -39,7 +39,7 @@ def user_payload() -> dict[str, Any]:
 @patch("assistant.app.init_assistant_service")
 @patch("assistant.app.init_engine")
 @patch("assistant.app.init_vdb")
-def test_invoke_success(mock_vdb, mock_engine, mock_service, user_payload, dummy_usage):
+def test_invoke_success(mock_vdb, mock_engine, mock_service, user_payload, dummy_usage, patch_configs):
     """/invoke returns AgentResponse and disposes engine on shutdown."""
 
     fake_response = AssistantResponse(output="hi!", usage=dummy_usage)
@@ -72,7 +72,7 @@ def test_invoke_success(mock_vdb, mock_engine, mock_service, user_payload, dummy
 @patch("assistant.app.init_assistant_service", lambda *a, **kw: AsyncMock())
 @patch("assistant.app.init_engine", lambda *a, **kw: AsyncMock())
 @patch("assistant.app.init_vdb", lambda *a, **kw: MagicMock())
-def test_invoke_validation_error(user_payload):
+def test_invoke_validation_error(user_payload, patch_configs):
     """Test validation error when chat_uid is missing."""
     payload = user_payload.copy()
     payload.pop("chat_uid")
@@ -88,7 +88,7 @@ def test_invoke_validation_error(user_payload):
 @patch("assistant.app.init_assistant_service")
 @patch("assistant.app.init_engine", lambda *a, **kw: AsyncMock())
 @patch("assistant.app.init_vdb", lambda *a, **kw: MagicMock())
-def test_invoke_service_error(mock_service, user_payload):
+def test_invoke_service_error(mock_service, user_payload, patch_configs):
     """Test error handling when assistant service raises exception."""
     err = RuntimeError("model crashed")
     mock_service_instance = AsyncMock()

--- a/tests/assistant/test_inits.py
+++ b/tests/assistant/test_inits.py
@@ -39,9 +39,7 @@ def test_init_assistant_service_missing_agent_keys(fake_load_expanto_cfg):
     """Test initialization fails when assistant keys are missing."""
     with pytest.raises(ValueError, match="Api keys.*not set"):
         secrets = MagicMock(api_keys=None)
-        init_assistant_service(
-            secrets=secrets, config=fake_load_expanto_cfg
-        )
+        init_assistant_service(secrets=secrets, config=fake_load_expanto_cfg)
 
 
 def test_init_assistant_service_missing_together_key(fake_load_expanto_cfg):

--- a/tests/assistant/test_models.py
+++ b/tests/assistant/test_models.py
@@ -64,7 +64,7 @@ def test_factory_methods_return_correct_model(
     call_args = model_cls.call_args
     assert call_args.kwargs["model_name"] == expected_model_name
     assert call_args.kwargs["provider"] is provider_cls.return_value
-    
+
     # For router model, verify settings parameter is passed
     if method_name == "create_router_model":
         assert "settings" in call_args.kwargs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
@@ -9,7 +7,17 @@ from sqlalchemy.orm import Session
 from src.domain.models import Base, CalculationJob, Experiment, Observation, Precompute
 from src.services.metric_register import Metrics
 from src.settings import Config, QueryTemplatesConfig, Secrets
-from src.utils import DatetimeUtils
+from tests.assets.configs import dir_fake_metrics, dir_fake_query, fake_configs_dict, fake_secrets_dict
+from tests.assets.entities import (
+    calculation_jobs_content,
+    experiments_content,
+    insert_experiment,
+    insert_job,
+    insert_observation,
+    insert_precompute,
+    observations_content,
+    precomputes_content,
+)
 
 # ------------------------ INTERNAL DB FIXTURES (SQLALCHEMY) ------------------------
 
@@ -48,414 +56,67 @@ def session(engine: Engine, tables):
 
 
 @pytest.fixture(scope="function")
-def mock_experiments(session: Session):
+def mock_experiments(session: Session) -> list[Experiment]:
     """Create mock experiment data for testing."""
-    # Create two experiments
-    exp1 = Experiment(
-        name="Button Color Test",
-        status="completed",
-        description="Testing the impact of button color on conversion rates",
-        hypotheses="Blue buttons will increase conversion rates by 10%",
-        key_metrics=["conversion_rate", "click_through_rate"],
-        design="A/B test with 50/50 split",
-        conclusion="Blue buttons increased conversion by 8%",
-        start_datetime=DatetimeUtils.utc_now() - timedelta(days=30),
-        end_datetime=DatetimeUtils.utc_now() - timedelta(days=15),
-        _created_at=DatetimeUtils.utc_now() - timedelta(days=45),
-    )
-
-    exp2 = Experiment(
-        name="Pricing Page Redesign",
-        status="running",
-        description="Testing new pricing page layout",
-        hypotheses="New layout will increase subscription rates",
-        key_metrics=["subscription_rate", "time_to_subscribe"],
-        design="A/B test with 70/30 split",
-        start_datetime=DatetimeUtils.utc_now() - timedelta(days=10),
-        end_datetime=DatetimeUtils.utc_now() - timedelta(days=10),
-        _created_at=DatetimeUtils.utc_now() - timedelta(days=20),
-    )
-
-    session.add_all([exp1, exp2])
-    session.commit()
-    session.refresh(exp1)
-    session.refresh(exp2)
+    exp1 = insert_experiment(session, **experiments_content[0])
+    exp2 = insert_experiment(session, **experiments_content[1])
     return [exp1, exp2]
 
 
 @pytest.fixture(scope="function")
-def mock_observations(session, mock_experiments):
+def mock_observations(session, mock_experiments) -> list[Observation]:
     """Create mock observation data for testing."""
-    # Create three observations
-    obs1 = Observation(
-        experiment_id=mock_experiments[0].id,
-        name="Main Conversion Analysis",
-        db_experiment_name="button_color_test",
-        split_id="user_id",
-        calculation_scenario="base",
-        exposure_start_datetime=DatetimeUtils.utc_now() - timedelta(days=30),
-        exposure_end_datetime=DatetimeUtils.utc_now() - timedelta(days=15),
-        calc_start_datetime=DatetimeUtils.utc_now() - timedelta(days=30),
-        calc_end_datetime=DatetimeUtils.utc_now() - timedelta(days=15),
-        exposure_event="page_view",
-        audience_tables=["active_users"],
-        filters=["platform='web'", "country in ('USA', 'FR')"],
-        custom_test_ids_query="select * from test_ids",
-        metric_tags=["conversion"],
-        metric_groups=["engagement"],
-        _created_at=DatetimeUtils.utc_now() - timedelta(days=44),
-    )
-
-    obs2 = Observation(
-        experiment_id=mock_experiments[0].id,
-        name="Mobile Users Analysis",
-        db_experiment_name="button_color_test",
-        split_id="device_id",
-        calculation_scenario="base",
-        exposure_start_datetime=DatetimeUtils.utc_now() - timedelta(days=30),
-        exposure_end_datetime=DatetimeUtils.utc_now() - timedelta(days=15),
-        calc_start_datetime=DatetimeUtils.utc_now() - timedelta(days=30),
-        calc_end_datetime=DatetimeUtils.utc_now() - timedelta(days=15),
-        exposure_event="mobile_page_view",
-        audience_tables=["mobile_users"],
-        filters=["platform='mobile'"],
-        custom_test_ids_query="select * from test_ids",
-        metric_tags=["mobile"],
-        metric_groups=["engagement"],
-        _created_at=DatetimeUtils.utc_now() - timedelta(days=45),
-    )
-
-    obs3 = Observation(
-        experiment_id=mock_experiments[1].id,
-        name="Pricing Page Analysis",
-        db_experiment_name="pricing_page_redesign",
-        split_id="user_id",
-        calculation_scenario="base",
-        exposure_start_datetime=DatetimeUtils.utc_now() - timedelta(days=10),
-        exposure_end_datetime=DatetimeUtils.utc_now() - timedelta(days=10),
-        calc_start_datetime=DatetimeUtils.utc_now() - timedelta(days=10),
-        calc_end_datetime=DatetimeUtils.utc_now() - timedelta(days=10),
-        exposure_event="pricing_page_view",
-        audience_tables=["potential_subscribers"],
-        filters=["has_visited_pricing=true"],
-        custom_test_ids_query="select * from test_ids",
-        metric_tags=["pricing"],
-        metric_groups=["conversion"],
-        _created_at=DatetimeUtils.utc_now() - timedelta(days=46),
-    )
-
-    session.add_all([obs1, obs2, obs3])
-    session.commit()
+    obs1 = insert_observation(session, int(mock_experiments[0].id), **observations_content[0])
+    obs2 = insert_observation(session, int(mock_experiments[0].id), **observations_content[1])
+    obs3 = insert_observation(session, int(mock_experiments[1].id), **observations_content[2])
     return [obs1, obs2, obs3]
 
 
 @pytest.fixture(scope="function")
-def mock_precomputes(session, mock_calculation_jobs):
-    """Create mock precompute data for testing."""
-    # Create seven precomputes
-    precomputes = []
-
-    # Three precomputes for first job
-    precomputes.extend(
-        [
-            Precompute(
-                job_id=mock_calculation_jobs[0].id,
-                group_name="control",
-                metric_name="conversion_rate",
-                metric_display_name="Conversion Rate",
-                metric_type="ratio",
-                observation_cnt=1000,
-                metric_value=0.15,
-                numerator_avg=150,
-                denominator_avg=1000,
-                numerator_var=127.5,
-                denominator_var=0,
-                covariance=0,
-                _created_at=DatetimeUtils.utc_now() - timedelta(days=44),
-            ),
-            Precompute(
-                job_id=mock_calculation_jobs[0].id,
-                group_name="treatment",
-                metric_name="conversion_rate",
-                metric_display_name="Conversion Rate",
-                metric_type="ratio",
-                observation_cnt=1000,
-                metric_value=0.18,
-                numerator_avg=180,
-                denominator_avg=1000,
-                numerator_var=147.6,
-                denominator_var=0,
-                covariance=0,
-                _created_at=DatetimeUtils.utc_now() - timedelta(days=44),
-            ),
-        ]
-    )
-
-    # Two precomputes for third job (mobile metrics)
-    precomputes.extend(
-        [
-            Precompute(
-                job_id=mock_calculation_jobs[2].id,
-                group_name="control",
-                metric_name="mobile_conversion_rate",
-                metric_display_name="Conversion Rate in Mobile",
-                metric_type="ratio",
-                observation_cnt=500,
-                metric_value=0.12,
-                numerator_avg=60,
-                denominator_avg=500,
-                numerator_var=52.8,
-                denominator_var=0,
-                covariance=0,
-                _created_at=DatetimeUtils.utc_now() - timedelta(days=44),
-            ),
-        ]
-    )
-
-    # Two precomputes for fourth job (pricing metrics)
-    precomputes.extend(
-        [
-            Precompute(
-                job_id=mock_calculation_jobs[3].id,
-                group_name="control",
-                metric_name="subscription_rate",
-                metric_display_name="Subscription Rate",
-                metric_type="ratio",
-                observation_cnt=300,
-                metric_value=0.08,
-                numerator_avg=24,
-                denominator_avg=300,
-                numerator_var=22.08,
-                denominator_var=0,
-                covariance=0,
-                _created_at=DatetimeUtils.utc_now() - timedelta(days=19),
-            ),
-        ]
-    )
-
-    session.add_all(precomputes)
-    session.commit()
-    return precomputes
+def mock_calculation_jobs(session, mock_observations) -> list[CalculationJob]:
+    """Create mock calculation job data for testing."""
+    job1 = insert_job(session, int(mock_observations[0].id), **calculation_jobs_content[0])
+    job2 = insert_job(session, int(mock_observations[1].id), **calculation_jobs_content[1])
+    job3 = insert_job(session, int(mock_observations[1].id), **calculation_jobs_content[2])
+    job4 = insert_job(session, int(mock_observations[2].id), **calculation_jobs_content[3])
+    return [job1, job2, job3, job4]
 
 
 @pytest.fixture(scope="function")
-def mock_calculation_jobs(session, mock_observations):
-    """Create mock calculation job data for testing."""
-    # Create four calculation jobs
-    jobs = [
-        CalculationJob(
-            observation_id=mock_observations[0].id,
-            query="SELECT * FROM metrics WHERE experiment_id = 1",
-            status="completed",
-            extra={"execution_time_ms": 1200, "bytes_read": 1024000},
-            _created_at=DatetimeUtils.utc_now() - timedelta(days=44),
-        ),
-        CalculationJob(
-            observation_id=mock_observations[0].id,
-            query="SELECT * FROM metrics WHERE experiment_id = 1 AND date > '2024-01-01'",
-            status="failed",
-            error_message="Timeout error",
-            extra={"execution_time_ms": 30000, "error_code": "TIMEOUT"},
-            _created_at=DatetimeUtils.utc_now() - timedelta(days=43),
-        ),
-        CalculationJob(
-            observation_id=mock_observations[1].id,
-            query="SELECT * FROM mobile_metrics WHERE experiment_id = 1",
-            status="completed",
-            extra={"execution_time_ms": 800, "bytes_read": 512000, "cache_hit": True},
-            _created_at=DatetimeUtils.utc_now() - timedelta(days=44),
-        ),
-        CalculationJob(
-            observation_id=mock_observations[2].id,
-            query="SELECT * FROM pricing_metrics WHERE experiment_id = 2",
-            status="running",
-            extra={"start_time": "2024-01-01T10:00:00Z"},
-            _created_at=DatetimeUtils.utc_now() - timedelta(days=19),
-        ),
-    ]
-
-    session.add_all(jobs)
-    session.commit()
-    return jobs
+def mock_precomputes(session, mock_calculation_jobs) -> list[Precompute]:
+    """Create mock precompute data for testing."""
+    precompute1 = insert_precompute(session, int(mock_calculation_jobs[0].id), **precomputes_content[0])
+    precompute2 = insert_precompute(session, int(mock_calculation_jobs[0].id), **precomputes_content[1])
+    precompute3 = insert_precompute(session, int(mock_calculation_jobs[2].id), **precomputes_content[2])
+    precompute4 = insert_precompute(session, int(mock_calculation_jobs[3].id), **precomputes_content[3])
+    return [precompute1, precompute2, precompute3, precompute4]
 
 
 # -------------------------------- METRICS FIXTURES --------------------------------
 @pytest.fixture(scope="session")
-def metrics_temp_dir(tmp_path_factory):
-    """Create temporary directory with mock metrics YAML files."""
-    temp_dir = tmp_path_factory.mktemp("metrics_data")
-
-    file1_content = """
-    metric_group_name: 'Order Metrics'
-    user_aggregations:
-      product_purchase_cnt: &product_purchase_cnt
-        alias: product_purchase_cnt
-        sql: COUNT(CASE event_name WHEN 'product_purchased' THEN event_name ELSE null END)
-
-      product_revenue_sum: &product_revenue_sum
-        alias: product_revenue_sum
-        sql: SUM(CASE event_name WHEN 'product_purchased' THEN event_value ELSE 0 END)
-
-    metrics:
-      - alias: avg_order_value
-        type: ratio
-        display_name: "Average Order Value"
-        description: "Sum of product purchase revenue divided by count"
-        formula:
-          numerator: *product_revenue_sum
-          denominator: *product_purchase_cnt
-        owner: me
-        tags: ["orders", "sales"]
-    """
-
-    file2_content = """
-        metric_group_name: 'User Behavior and Engagement Metrics'
-        user_aggregations:
-          product_view_cnt: &product_view_cnt
-            alias: product_view_cnt
-            sql: COUNT(CASE event_name WHEN 'product_viewed' THEN event_name ELSE null END)
-    
-          session_duration: &session_duration
-            alias: session_duration
-            sql: AVG(session_length)
-    
-          product_click_flg: &product_click_flg
-            alias: product_click_flg
-            sql: MAX(CASE event_name WHEN 'product_clicked' THEN 1 ELSE 0 END)
-    
-          product_purchase_flg: &product_purchase_flg
-            alias: product_purchase_flg
-            sql: MAX(CASE event_name WHEN 'product_purchased' THEN 1 ELSE 0 END)
-
-          product_view_flg: &product_view_flg
-            alias: product_view_flg
-            sql: MAX(CASE event_name WHEN 'product_viewed' THEN 1 ELSE 0 END)
-    
-        metrics:
-          - alias: click_through_rate
-            type: ratio
-            display_name: "CTR"
-            description: "Product clicks vs product views"
-            formula:
-              numerator: *product_click_flg
-              denominator: *product_view_cnt
-            owner: me
-            tags: ["engagement", "ui"]
-    
-          - alias: conversion_rate
-            type: avg
-            display_name: "Conversion Rate"
-            description: "Product purchases vs product views"
-            formula:
-              numerator: *product_purchase_flg
-              denominator: null
-            owner: me
-            tags: ["conversion", "sales"]
-    
-          - alias: avg_session_duration
-            type: avg
-            display_name: "Avg Session Duration"
-            description: "Average session length per user"
-            formula:
-              numerator: *session_duration
-              denominator: null
-            owner: me
-            tags: ["behavior", "time"]
-    
-          - alias: users_who_click_product_ratio
-            type: proportion
-            display_name: "Users with Orders"
-            description: "some description"
-            formula:
-              numerator: *product_click_flg
-              denominator: null
-            owner: me
-            tags: null
-        """
-
-    (temp_dir / "order_metrics.yaml").write_text(file1_content)
-    (temp_dir / "engagement_metrics.yaml").write_text(file2_content)
-
-    return temp_dir
+def metrics_temp_dir():
+    """Return path to bundled test metrics directory under tests/assets/metrics."""
+    return dir_fake_metrics
 
 
-@pytest.fixture
-def metrics(metrics_temp_dir):
+@pytest.fixture(scope="session")
+def metrics(metrics_temp_dir) -> Metrics:
     """Create Metrics instance from temporary directory."""
     return Metrics(directory=str(metrics_temp_dir))
 
 
 # -------------------------------- QUERIES FIXTURES --------------------------------
-@pytest.fixture
-def queries_templates_config(tmp_path_factory):
-    """Create temporary directory with query templates for testing."""
-    temp_dir = tmp_path_factory.mktemp("queries")
-    base_dir = temp_dir / "base"
-    base_dir.mkdir()
-
-    # Create a sample base query template
-    base_query = """
-        WITH fake_template AS (
-        SELECT 
-            {{ observation.split_id }} as split_id
-            {% if purpose == 'planning' %} ,'planning' as purpose
-            {% else %},'result' as purpose {% endif %} 
-            {% for user_formula in user_formula_list %}
-            , {{ user_formula.sql }} as {{ user_formula.alias }}{% endfor %}
-        FROM {% if observation.segment %}{{ observation.segment }}
-             {% else %} {{ observation.db_experiment_name }}
-             {% endif %}
-        WHERE 1 = 1
-            AND exposure_timestamp BETWEEN '{{ observation.exposure_start_datetime }}' AND '{{ observation.exposure_end_datetime }}' 
-            AND event_timestamp BETWEEN '{{ observation.calc_start_datetime }}' AND '{{ observation.calc_end_datetime }}'
-            {% if observation.filters %}
-            {% for filter in observation.filters %}
-            AND ({{ filter }}){% if not loop.last %} {% endif %}
-            {% endfor %}{% endif %}
-            {% if observation.audience_tables %}
-            AND EXISTS (
-                SELECT 1 FROM {% for table in observation.audience_tables %}
-                {{ table }}{% if not loop.last %} UNION ALL {% endif %}
-                {% endfor %}
-            ){% endif %}
-        GROUP BY 1
-        {% for metric in experiment_metrics_list %}
-        SELECT
-              GROUP_NAME as group_name
-             , '{{ metric.alias }}' as metric_name
-             , '{{ metric.type }}' as metric_type
-             , '{{ metric.display_name }}' as metric_display_name
-             , COUNT(distinct fake_template.{{ observation.split_id }}) as observations_cnt
-             , {{ metric.sql }} as metric_value
-             , AVG({{ metric.formula.numerator.alias }}) as numerator_avg
-             , VAR_SAMP({{ metric.formula.numerator.alias }}) as numerator_var
-             {% if metric.formula.denominator -%}
-             , AVG({{ metric.formula.denominator.alias }}) as denominator_avg
-             , VAR_SAMP({{ metric.formula.denominator.alias }}) as denominator_var
-             , COVAR_SAMP({{ metric.formula.denominator.alias }}, {{ metric.formula.numerator.alias }}) as covariance
-             {% else -%}
-             , CAST(null as float) as denominator_avg
-             , CAST(null as float) as denominator_var
-             , CAST(null as float) as covariance
-             {% endif -%}
-        FROM fake_template
-        GROUP BY group_name
-            {% if not loop.last %}
-        UNION ALL{% endif %}
-        {% endfor %}
-        )
-    """  # noqa: E501
-    (base_dir / "base.sql").write_text(base_query)
-
-    return QueryTemplatesConfig(dir=str(temp_dir), scenarios= {'base': "base/base.sql"})
+@pytest.fixture(scope="session")
+def queries_templates_config() -> QueryTemplatesConfig:
+    """Return path to bundled test query template under tests/assets/query.j2."""
+    return QueryTemplatesConfig(dir=str(dir_fake_query), scenarios={"base": "query.j2"})
 
 
-# --------------------------- OTHER FIXTURES ---------------------------
+# --------------------------- CONFIG FIXTURES ---------------------------
 
 
 @pytest.fixture
 def disable_files_in_settings(monkeypatch):
-    """Force Config() and Secrets() to use only __init__ and env sources."""
     """Force Config() and Secrets() to use only __init__ and env sources."""
 
     def only_init_and_env(
@@ -484,114 +145,13 @@ def disable_files_in_settings(monkeypatch):
 
 
 @pytest.fixture
-def fake_load_expanto_cfg(metrics_temp_dir, queries_templates_config):
+def fake_load_expanto_cfg(metrics_temp_dir, queries_templates_config) -> Config:
     """Create fake Expanto configuration for testing."""
-    return Config.model_validate(
-        {
-            "metrics": {"dir": str(metrics_temp_dir)},
-            "queries": {
-                "dir": queries_templates_config.dir,
-                "scenarios": {
-                    "base": "base/base.sql",
-                    "base2": "base2",
-                }
-            },
-            "precompute_db": {"name": "snowflake"},
-            "assistant": {
-                "provider": "super_druper_provider",
-                "models": {
-                    "fast": "Q",
-                    "agentic": "Q",
-                    "tool_thinker": "Q",
-                },
-                "service": {
-                    "url": "http://127.0.0.1:8000",
-                    "timeout_seconds": 600,
-                    "enable_streaming": True,
-                    "auto_scroll": True,
-                },
-            },
-            "logfire":{"send_to_logfire": False}
-        }
-    )
+    return Config.model_validate(fake_configs_dict)
 
 
 @pytest.fixture
-def fake_load_secrets_cfg(db_path):
+def fake_load_secrets_cfg(db_path) -> Secrets:
     """Create fake secrets configuration for testing."""
-    return Secrets.model_validate(
-        {
-            "internal_db": {
-                "engine_str": db_path,
-                "async_engine_str": "fake",
-                "connect_args": {},
-            },
-            "bigquery": {
-                "file_path": "fake",
-                "project_name": "fake",
-                "connection_type": "application_default",
-            },
-            "snowflake": None,
-            "api_keys": {
-                "PROVIDER_API_KEY": "TOGETHER_API_KEY",
-                 "TAVILY_API_KEY": "TAVILY_API_KEY",
-                 "LOGFIRE_TOKEN": "LOGFIRE_TOKEN"
-            },
-        },
-    )
-
-
-@pytest.fixture
-def patch_configs(
-    monkeypatch, disable_files_in_settings, fake_load_secrets_cfg, fake_load_expanto_cfg, engine, metrics
-):
-    """Patch configuration loading for UI testing."""
-    monkeypatch.setattr(
-        "src.ui.resources.Secrets",
-        lambda *a, **kw: fake_load_secrets_cfg,
-        raising=True,
-    )
-
-    # Same for Config()
-    monkeypatch.setattr(
-        "src.ui.resources.Config",
-        lambda *a, **kw: fake_load_expanto_cfg,
-        raising=True,
-    )
-
-
-@pytest.fixture
-def patch_client_and_resolver():
-    """Mock BigQuery client and connector resolver for testing."""
-    with patch("src.services.runners.connectors.bigquery.Client") as MockClient:
-        inst = MockClient.from_service_account_json.return_value
-
-        with patch("src.services.runners.connectors.ConnectorResolver.resolve", return_value=inst):
-            yield inst
-
-
-@pytest.fixture(scope="session")
-def docs_temp_dir(tmp_path_factory):
-    """Create temporary directory with mock documentation files."""
-    temp_dir = tmp_path_factory.mktemp("docs")
-    (temp_dir / "integration.md").write_text("Integration documentation. how to start with expanto")
-    (temp_dir / "queries.md").write_text("Queries documentation. how to create queries")
-    (temp_dir / "precompute.md").write_text("Precompute documentation. how to create precompute")
-    (temp_dir / "metrics.md").write_text("Metrics documentation. how to create metrics")
-    return temp_dir
-
-
-@pytest.fixture(scope="session")
-def root_dir(tmp_path_factory):
-    """Create temporary root directory structure for testing."""
-    temp_dir = tmp_path_factory.mktemp("root")
-    (temp_dir / "src").mkdir()
-    (temp_dir / ".expanto").mkdir()
-    (temp_dir / "src" / "agent").mkdir()
-    (temp_dir / "src" / "services").mkdir()
-    (temp_dir / "src" / ".env").write_text("ENV_VAR=!!!")
-    (temp_dir / "src" / "agent" / "vdb.py").write_text("This is a vdb code")
-    (temp_dir / "src" / "services" / "metric_register.py").write_text("This is a metric register code")
-    (temp_dir / "src" / "services" / "bigquery.py").write_text("This is a bigquery code")
-    (temp_dir / ".expanto" / "secrets.toml").write_text("SECRET_KEY=000111")
-    return temp_dir
+    fake_secrets_dict["internal_db"]["engine_str"] = db_path
+    return Secrets.model_validate(fake_secrets_dict)

--- a/tests/services/runners/test_connectors.py
+++ b/tests/services/runners/test_connectors.py
@@ -11,8 +11,6 @@ from src.services.runners.connectors import (
 )
 from src.settings import (
     BigQueryCredentials,
-    InternalDBConfig,
-    Secrets,
     SnowflakeCredentials,
 )
 
@@ -164,38 +162,20 @@ def test_run_query_error_snowflake(creds_bigquery_service_account):
         connector.run_query("dummy")
 
 
-def test_resolve_snowflake(creds_snowflake, fake_load_expanto_cfg):
+def test_resolve_snowflake(creds_snowflake, fake_load_expanto_cfg, fake_load_secrets_cfg):
     """Test resolver returns Snowflake connector for snowflake config."""
     config = fake_load_expanto_cfg
     config.precompute_db.name = "snowflake"
-    secrets = Secrets(
-        snowflake=creds_snowflake,
-        internal_db=InternalDBConfig(
-            **{
-                "engine_str": "sqlite:///:memory:",
-                "async_engine_str": "sqlite+aiosqlite:///:memory:",
-                "connect_args": {"check_same_thread": False},
-            }
-        ),
-    )
+    secrets = fake_load_secrets_cfg
     connector = ConnectorResolver.resolve(precompute_db_name=config.precompute_db.name, secrets=secrets)
     assert isinstance(connector, SnowflakeConnector)
 
 
-def test_resolve_bigquery(creds_bigquery_service_account, fake_load_expanto_cfg):
+def test_resolve_bigquery(creds_bigquery_service_account, fake_load_expanto_cfg, fake_load_secrets_cfg):
     """Test resolver returns BigQuery connector for bigquery config."""
     config = fake_load_expanto_cfg
     config.precompute_db.name = "bigquery"
-    secrets = Secrets(
-        bigquery=creds_bigquery_service_account,
-        internal_db=InternalDBConfig(
-            **{
-                "engine_str": "sqlite:///:memory:",
-                "async_engine_str": "sqlite+aiosqlite:///:memory:",
-                "connect_args": {"check_same_thread": False},
-            }
-        ),
-    )
+    secrets = fake_load_secrets_cfg
     connector = ConnectorResolver.resolve(precompute_db_name=config.precompute_db.name, secrets=secrets)
 
     assert isinstance(connector, BigQueryConnector)

--- a/tests/ui/chat/test_chat.py
+++ b/tests/ui/chat/test_chat.py
@@ -13,17 +13,30 @@ def app_script():
     Chat.render()
 
 
-@pytest.fixture
-def app():
+def make_success_response():
+    """Create mock successful ChatResponse for testing."""
+    return ChatResponse(
+        chat_msg="Hello",
+        supplement=None,
+        success=True,
+        usage=TokenUsage(requests=1, request_tokens=10, response_tokens=10, total_tokens=20, details={}),
+        error_msg=None,
+    )
+
+
+@pytest.fixture(scope="function")
+def app(patch_configs):
     """Fixture providing AppTest instance for Chat component testing."""
     at = AppTest.from_function(app_script)
     at.run()
     return at
 
 
-def test_active_user_input_reset(app):
+@patch("src.ui.chat.chat.ChatController.process_user_input", return_value=make_success_response())
+def test_active_user_input_reset(mock_process, app):
     """Test that active user input is reset after message submission."""
     app.chat_input[0].set_value("ping").run()
+    print(app)
     assert app.session_state["chat_state"].active_user_input is None
 
 
@@ -64,17 +77,6 @@ def test_user_input_error_response(app):
     assert app.session_state["chat_state"].msg_history[-1].role == Role.ASSISTANT
     assert "Error" in app.session_state["chat_state"].msg_history[-1].content
     assert app.session_state["chat_state"].active_user_input is None
-
-
-def make_success_response():
-    """Create mock successful ChatResponse for testing."""
-    return ChatResponse(
-        chat_msg="Hello",
-        supplement=None,
-        success=True,
-        usage=TokenUsage(requests=1, request_tokens=10, response_tokens=10, total_tokens=20, details={}),
-        error_msg=None,
-    )
 
 
 @patch("src.ui.chat.chat.ChatController.process_user_input", return_value=make_success_response())

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def patch_configs(
+    monkeypatch, disable_files_in_settings, fake_load_secrets_cfg, fake_load_expanto_cfg, engine, metrics
+):
+    """Patch configuration loading for UI testing."""
+    monkeypatch.setattr(
+        "src.ui.resources.Secrets",
+        lambda *a, **kw: fake_load_secrets_cfg,
+        raising=True,
+    )
+
+    # Same for Config()
+    monkeypatch.setattr(
+        "src.ui.resources.Config",
+        lambda *a, **kw: fake_load_expanto_cfg,
+        raising=True,
+    )
+
+
+@pytest.fixture
+def patch_client_and_resolver():
+    """Mock BigQuery client and connector resolver for testing."""
+    with patch("src.services.runners.connectors.bigquery.Client") as MockClient:
+        inst = MockClient.from_service_account_json.return_value
+
+        with patch("src.services.runners.connectors.ConnectorResolver.resolve", return_value=inst):
+            yield inst

--- a/tests/ui/test_common.py
+++ b/tests/ui/test_common.py
@@ -1,17 +1,18 @@
 """Tests for UI common utilities."""
 
-import streamlit as st
+import pytest
 from streamlit.testing.v1 import AppTest
 
 from src.domain.enums import PageMode
 from src.ui.common import URLParams
-import pytest
+
 
 def url_params_app():
     """Test Streamlit app for URLParams parsing."""
     import streamlit as st
+
     from src.ui.common import URLParams
-    
+    st.write("Streamlit")
     result = URLParams.parse()
     st.session_state["parsed_url_params"] = result
 
@@ -19,39 +20,93 @@ def url_params_app():
 @pytest.mark.parametrize(
     "query_params, expected_params",
     [
-        ( # Happy path - all valid parameters
-            {"observation_id": "123", "job_id": "456", "experiment_id": "789", "mode": "List", "submode": "details"}, 
-            {"observation_id": 123, "job_id": 456, "experiment_id": 789, "mode": PageMode.LIST, "submode": "details"}
+        (  # Happy path - all valid parameters
+            {
+                "observation_id": "123",
+                "job_id": "456",
+                "experiment_id": "789",
+                "mode": "List",
+                "submode": "details",
+            },
+            {
+                "observation_id": 123,
+                "job_id": 456,
+                "experiment_id": 789,
+                "mode": PageMode.LIST,
+                "submode": "details",
+            },
         ),
-        ( # Partial parameters
-            {"experiment_id": "42", "mode": "Create"}, 
-            {"observation_id": None, "job_id": None, "experiment_id": 42, "mode": PageMode.CREATE, "submode": None}
+        (  # Partial parameters
+            {"experiment_id": "42", "mode": "Create"},
+            {
+                "observation_id": None,
+                "job_id": None,
+                "experiment_id": 42,
+                "mode": PageMode.CREATE,
+                "submode": None,
+            },
         ),
-        ( # Empty parameters
-            {}, 
-            {"observation_id": None, "job_id": None, "experiment_id": None, "mode": None, "submode": None}
+        (  # Empty parameters
+            {},
+            {"observation_id": None, "job_id": None, "experiment_id": None, "mode": None, "submode": None},
         ),
-        ( # Invalid integer parameters
-            {"observation_id": "not_a_number", "job_id": "abc", "experiment_id": "12.5"}, 
-            {"observation_id": None, "job_id": None, "experiment_id": None, "mode": None, "submode": None}
+        (  # Invalid integer parameters
+            {"observation_id": "not_a_number", "job_id": "abc", "experiment_id": "12.5"},
+            {"observation_id": None, "job_id": None, "experiment_id": None, "mode": None, "submode": None},
         ),
-        ( # Mixed valid and invalid parameters
-            {"observation_id": "123", "job_id": "invalid", "experiment_id": "456", "mode": "BadMode", "submode": "valid_sub"}, 
-            {"observation_id": 123, "job_id": None, "experiment_id": 456, "mode": None, "submode": "valid_sub"}
+        (  # Mixed valid and invalid parameters
+            {
+                "observation_id": "123",
+                "job_id": "invalid",
+                "experiment_id": "456",
+                "mode": "BadMode",
+                "submode": "valid_sub",
+            },
+            {
+                "observation_id": 123,
+                "job_id": None,
+                "experiment_id": 456,
+                "mode": None,
+                "submode": "valid_sub",
+            },
         ),
-        ( # Very long submode string
-            {"submode": "a" * 1000}, 
-            {"observation_id": None, "job_id": None, "experiment_id": None, "mode": None, "submode": "a" * 1000}
+        (  # Very long submode string
+            {"submode": "a" * 1000},
+            {
+                "observation_id": None,
+                "job_id": None,
+                "experiment_id": None,
+                "mode": None,
+                "submode": "a" * 1000,
+            },
         ),
-        ( # Minimum and maximum integer values
-            {"observation_id": str(-2**63), "job_id": str(2**63 - 1)}, 
-            {"observation_id": -2**63, "job_id": 2**63 - 1, "experiment_id": None, "mode": None, "submode": None}
+        (  # Minimum and maximum integer values
+            {"observation_id": str(-(2**63)), "job_id": str(2**63 - 1)},
+            {
+                "observation_id": -(2**63),
+                "job_id": 2**63 - 1,
+                "experiment_id": None,
+                "mode": None,
+                "submode": None,
+            },
         ),
-        ( # Edge case: all fields with None-inducing values
-            {"observation_id": "NaN", "job_id": "infinity", "experiment_id": "null", "mode": "undefined", "submode": None}, 
-            {"observation_id": None, "job_id": None, "experiment_id": None, "mode": None, "submode": "None"}
+        (  # Edge case: all fields with None-inducing values
+            {
+                "observation_id": "NaN",
+                "job_id": "infinity",
+                "experiment_id": "null",
+                "mode": "undefined",
+                "submode": None,
+            },
+            {
+                "observation_id": None,
+                "job_id": None,
+                "experiment_id": None,
+                "mode": None,
+                "submode": "None",
+            },
         ),
-    ]
+    ],
 )
 def test_url_params_parse(query_params, expected_params):
     """Test URLParams.parse() with various parameter combinations and edge cases."""

--- a/tests/ui/test_planner_page.py
+++ b/tests/ui/test_planner_page.py
@@ -17,6 +17,7 @@ def _clear_streamlit_caches():
 @pytest.fixture
 def planner_page_app_test():
     from src.ui.state import AppContextManager
+
     """Create AppTest instance for planner page testing."""
     at = AppTest.from_file("src/ui/planner/page.py")
     AppContextManager.get_or_create_state()
@@ -133,4 +134,5 @@ def test_planner_page_with_precomputes(planner_page_app_test, patch_configs, tab
         if chart_key:
             at.session_state["effect_size_chart"] = mock_selection
         at.run()
-        assert "### Selected Design" in at.markdown[-1].value
+        print(at)
+        assert "### Selected Design" in at.markdown[-2].value

--- a/tests/ui/test_results_page.py
+++ b/tests/ui/test_results_page.py
@@ -18,6 +18,7 @@ def _clear_streamlit_caches():
 @pytest.fixture
 def results_page_app_test():
     from src.ui.state import AppContextManager
+
     """Create AppTest instance for results page testing."""
     at = AppTest.from_file("src/ui/results/page.py")
     AppContextManager.get_or_create_state()


### PR DESCRIPTION
- Created centralized test assets in tests/assets/ directory:
- configs.py with reusable fake configuration dictionaries for database connections and API settings
- entities.py with test data factories for experiments, observations, calculation jobs, and precomputes
- query.j2 template for SQL generation testing
- metrics/ directory with sample YAML metric configurations
- Added module-specific conftest.py files for UI and assistant test configuration
- Refactored existing tests to use centralized fixtures instead of inline data definitions

fixed #9 