### PR TITLE
Bug/fix planner page

### DIFF
--- a/queries/bigquery_example/__entry__.j2
+++ b/queries/bigquery_example/__entry__.j2
@@ -1,15 +1,15 @@
 with
     events AS (
-        {% include "base_new/events.sql" %}
+        {% include "bigquery_example/events.sql" %}
     ),
     testids AS (
-        {% include "base_new/testids.sql" %}
+        {% include "bigquery_example/testids.sql" %}
     ),
     events_x_testids AS (
-        {% include "base_new/events_x_testids.sql" %}
+        {% include "bigquery_example/events_x_testids.sql" %}
     ),
     user_aggregation AS (
-        {% include "base_new/user_aggregation.sql" %}
+        {% include "bigquery_example/user_aggregation.sql" %}
     )
     aggregated AS (
         SELECT

--- a/queries/bigquery_example/user_aggregation.j2
+++ b/queries/bigquery_example/user_aggregation.j2
@@ -11,8 +11,8 @@ INNER JOIN {{ audience_table }} as audience_{{ loop.index }}
 WHERE 1=1
     AND exposure_timestamp BETWEEN '{{ observation.exposure_start_datetime }}'
         AND '{{ observation.exposure_end_datetime }}'
-    AND event_timestamp BETWEEN '{{ observation.calc_start_datetime }}'
-        AND '{{ observation.calc_end_datetime }}'
+    AND (event_timestamp BETWEEN '{{ observation.calc_start_datetime }}'
+        AND '{{ observation.calc_end_datetime }}' or event_timestamp is null)
     {%- if observation.filters -%}
     {%- for filter in observation.filters %}
     AND {{ filter }}

--- a/queries/snowflake_example/base.sql
+++ b/queries/snowflake_example/base.sql
@@ -1,5 +1,5 @@
 WITH user_aggregation AS (
-    {% include "base/user_aggregation.sql" %}
+    {% include "snowflake_example/user_aggregation.sql" %}
 )
 {% for experiment_metric in experiment_metrics_list %}
 SELECT

--- a/queries/snowflake_example/events_x_testids.sql
+++ b/queries/snowflake_example/events_x_testids.sql
@@ -1,11 +1,11 @@
 WITH raw_events_cte AS (
-        {% include "base/events.sql" %}
+        {% include "snowflake_example/events.sql" %}
     )
     , testids_cte AS (
        {%- if purpose == 'planning' -%}
-            {% include "base/dummy_testids.sql" %}
+            {% include "snowflake_example/dummy_testids.sql" %}
        {%- else -%}
-            {% include "base/testids.sql" %}
+            {% include "snowflake_example/testids.sql" %}
        {%- endif -%}
     )
 SELECT

--- a/queries/snowflake_example/user_aggregation.sql
+++ b/queries/snowflake_example/user_aggregation.sql
@@ -1,6 +1,6 @@
 
 WITH joined_events_testids AS (
-    {% include "base/events_x_testids.sql" %}
+    {% include "snowflake_example/events_x_testids.sql" %}
 )
 SELECT
    j.{{ observation.split_id }}

--- a/src/ui/data_loaders.py
+++ b/src/ui/data_loaders.py
@@ -7,11 +7,11 @@ All functions use Streamlit's caching mechanism to improve performance.
 
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 import streamlit as st
 
+from src.domain.results import JobResult
 from src.logger_setup import logger
 from src.services.entities.dtos import CalculationJobDTO, ExperimentDTO, ObservationDTO
 from src.services.entities.handlers import (
@@ -339,8 +339,9 @@ def get_precomputes_for_planning(
     exposure_end_datetime: datetime,
     exposure_event: str,
     split_id: str,
+    calculation_scenario: str,
     experiment_metric_names: list[str],
-) -> dict:
+) -> JobResult:
     """Run calculation and get metric precomputes for experiment planning.
 
     Creates a dummy observation with the provided parameters and runs calculations
@@ -373,7 +374,7 @@ def get_precomputes_for_planning(
         experiment_id=None,
         name=None,
         db_experiment_name=None,
-        calculation_scenario=None,
+        calculation_scenario=calculation_scenario,
         _created_at=None,
         _updated_at=None,
     )
@@ -384,7 +385,7 @@ def get_precomputes_for_planning(
         CalculationPurpose.PLANNING,
         experiment_metric_names=experiment_metric_names,
     )
-    return asdict(job_result) if job_result else {}
+    return job_result
 
 
 # ---------------------------------- OTHER ----------------------------------

--- a/src/ui/observations/inputs.py
+++ b/src/ui/observations/inputs.py
@@ -143,6 +143,25 @@ class ObservationFormData:
 
 
 @dataclass
+class CalculationScenarioSelectBox:
+    """Dataclass to hold calculation scenario data."""
+
+    selected_scenario: str
+
+    @classmethod
+    def render(cls, predefined_scenario: str | None = None) -> CalculationScenarioSelectBox:
+        scenario_list = load_calculation_scenarios()
+        scenario_value = predefined_scenario
+        default_index = scenario_list.index(scenario_value) if scenario_value in scenario_list else 0
+        calculation_scenario = st.selectbox(
+            "Calculation Scenario",
+            scenario_list,
+            index=default_index,
+        )
+        return cls(selected_scenario=calculation_scenario)
+
+
+@dataclass
 class ObservationFormInputs:
     """Dataclass to hold the observation form inputs and state."""
 
@@ -211,16 +230,19 @@ class ObservationFormInputs:
             with col1l2:
                 split_id = st.text_input("Split ID (required)", value=predefined.split_id)
             with col2l2:
-                scenario_list = load_calculation_scenarios()
-                scenario_value = str(predefined.calculation_scenario)
-                default_index = (
-                    scenario_list.index(scenario_value) if scenario_value in scenario_list else 0
-                )
-                calculation_scenario = st.selectbox(
-                    "Calculation Scenario",
-                    scenario_list,
-                    index=default_index,
-                )
+                calculation_scenario = CalculationScenarioSelectBox.render(
+                    str(predefined.calculation_scenario)
+                ).selected_scenario
+                # scenario_list = load_calculation_scenarios()
+                # scenario_value = str(predefined.calculation_scenario)
+                # default_index = (
+                #     scenario_list.index(scenario_value) if scenario_value in scenario_list else 0
+                # )
+                # calculation_scenario = st.selectbox(
+                #     "Calculation Scenario",
+                #     scenario_list,
+                #     index=default_index,
+                # )
             col1l3, col2l3 = st.columns(2)
             # dates and times
             utc_now_dt = dt_utils.utc_now().date()

--- a/src/ui/planner/inputs.py
+++ b/src/ui/planner/inputs.py
@@ -11,6 +11,7 @@ from src.ui.data_loaders import (
     get_available_exposure_events,
     get_experiment_by_id,
 )
+from src.ui.observations.inputs import CalculationScenarioSelectBox
 from src.ui.resources import load_metrics_handler
 
 
@@ -281,6 +282,7 @@ class DummyObsSelectedParams:
     exposure_end_datetime: date | None = None
     exposure_event: str | None = None
     split_id: str | None = None
+    calculation_scenario: str | None = None
     experiment_metric_names: list[str] | None = None
 
 
@@ -320,6 +322,7 @@ class GetPrecomputesForm:
             the selected parameters upon submission.
         """
         with st.form(f"Dummy Observation Params for {experiment_id_}"):
+            calculation_scenario = CalculationScenarioSelectBox.render().selected_scenario
             key_metrics_selectbox = KeyMetricsSelectBox.render(experiment_id_)
             time_input_section = TimeInputSection.render(experiment_id_)
             col1, col2 = st.columns(2)
@@ -359,6 +362,7 @@ class GetPrecomputesForm:
                         exposure_end_datetime=time_input_section.selected_exposure_end_datetime,
                         exposure_event=exposure_event_selectbox.selected_exposure_event,
                         split_id=split_id_selectbox.selected_split_id,
+                        calculation_scenario=calculation_scenario,
                         experiment_metric_names=key_metrics_selectbox.selected_metrics,
                     ),
                 )

--- a/tests/services/analytics/stat_functions/test_delta_method.py
+++ b/tests/services/analytics/stat_functions/test_delta_method.py
@@ -75,7 +75,7 @@ def generate_stats_by_ratio_samples(numerator_1, denominator_1, numerator_2, den
     [
         ([(100, 20, 50, 30, 0.5), (100, 20, 50, 30, 0.5)], 10000, 43, lambda pval: pval > 0.05),
         ([(100, 20, 50, 30, 0.1), (120, 20, 50, 30, 0.1)], 100000, 42, lambda pval: pval < 0.01),
-        ([(100, 20, 50, 30, 0.5), (120, 20, 50, 30, 0.5)], 1000, None, lambda pval: pval < 0.05),
+        ([(100, 20, 50, 30, 0.5), (120, 20, 50, 30, 0.5)], 1000, 100, lambda pval: pval < 0.05),
     ],
 )
 def test_ratio_metric_test_trivial(
@@ -99,7 +99,7 @@ def test_ratio_metric_test_trivial(
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "n_simulations, samples_params, sample_size, seed",
-    [(5000, (120, 20, 50, 30, 0.1), 2000, 122), (10000, (120, 20, 50, 30, 0.1), 20000, None)],
+    [(5000, (120, 20, 50, 30, 0.1), 2000, 122), (10000, (120, 20, 50, 30, 0.1), 20000, 55)],
 )
 def test_ratio_metric_test_reliability_norm(
     generate_samples_ratio, n_simulations, samples_params, sample_size, seed
@@ -129,7 +129,7 @@ def test_ratio_metric_test_reliability_norm(
 @pytest.mark.parametrize(
     "n_simulations, samples_params, sample_size, seed",
     # samples_params(lambda_n, lambda_d, correlation)
-    [(200000, (1 / 2, 1 / 20, 0.85), 5000, 120), (10000, (1 / 2, 1 / 10, 0.4), 20000, None)],
+    [(200000, (1 / 2, 1 / 20, 0.85), 5000, 120), (10000, (1 / 2, 1 / 10, 0.4), 20000, 1010)],
 )
 def test_ratio_metric_test_reliability_expon(
     generate_samples_ratio_expon, n_simulations, samples_params, sample_size, seed

--- a/tests/services/runners/test_executors.py
+++ b/tests/services/runners/test_executors.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
+import pytest
+
 from src.domain.enums import CalculationPurpose, JobStatus
+from src.domain.models import Observation
 from src.domain.results import MetricResult
+from src.services.entities.dtos import ObservationDTO
 from src.services.entities.handlers import JobHandler, PrecomputeHandler
 
 # ------------------------------- CalculationRunner -----------------------------
@@ -131,3 +135,184 @@ def test_calculation_runner_store_metrics_failure(
     executed_job = JobHandler(engine).get(1)
     assert executed_job.status == JobStatus.FAILED
     assert "Store error: DB connection failed" in executed_job.error_message
+
+
+# ------------------------ NEW TESTS FOR EDGE CASES ------------------------
+
+
+@pytest.mark.parametrize(
+    "obs_factory, expected_obs_id",
+    [
+        (
+            lambda: Observation(
+                id=1,
+                experiment_id=1,
+                name="SQLAlchemy Test Observation",
+                db_experiment_name="test_experiment_db_name",
+                split_id="user_id",
+                calculation_scenario="base",
+                exposure_start_datetime="2024-01-01",
+                exposure_end_datetime="2024-01-31",
+                calc_start_datetime="2024-01-01",
+                calc_end_datetime="2024-01-31",
+                exposure_event="view",
+                audience_tables=["active_users"],
+                filters=["platform='web'"],
+                custom_test_ids_query=None,
+            ),
+            1,
+        ),
+        (
+            lambda: ObservationDTO(
+                id=None,
+                experiment_id=None,
+                name="DTO Test Observation",
+                db_experiment_name="test_experiment_db_name",
+                split_id="user_id",
+                calculation_scenario="base",
+                exposure_start_datetime="2024-01-01",
+                exposure_end_datetime="2024-01-31",
+                calc_start_datetime="2024-01-01",
+                calc_end_datetime="2024-01-31",
+                exposure_event="view",
+                audience_tables=["active_users"],
+                filters=["platform='web'"],
+                custom_test_ids_query=None,
+                _created_at=None,
+                _updated_at=None,
+            ),
+            None,
+        ),
+        (
+            lambda: ObservationDTO(
+                id=42,
+                experiment_id=1,
+                name="DTO Test Observation with ID",
+                db_experiment_name="test_experiment_db_name",
+                split_id="user_id",
+                calculation_scenario="base",
+                exposure_start_datetime="2024-01-01",
+                exposure_end_datetime="2024-01-31",
+                calc_start_datetime="2024-01-01",
+                calc_end_datetime="2024-01-31",
+                exposure_event="view",
+                audience_tables=["active_users"],
+                filters=["platform='web'"],
+                custom_test_ids_query=None,
+                _created_at=None,
+                _updated_at=None,
+            ),
+            42,
+        ),
+    ],
+)
+def test_calculation_runner_with_different_observation_types(
+    mock_calculation_runner,
+    mock_metric_results,
+    engine,
+    tables,
+    obs_factory,
+    expected_obs_id,
+):
+    """Test calculation runner with different observation types and id scenarios."""
+    # Create observation using the factory function
+    obs = obs_factory()
+
+    # Mock the connector to return metric results
+    mock_calculation_runner.exec._connector.fetch_results.return_value = mock_metric_results
+
+    # Determine purpose based on observation type
+    purpose = CalculationPurpose.PLANNING if expected_obs_id is None else CalculationPurpose.REGULAR
+
+    # Execute with the observation
+    result = mock_calculation_runner.run_calculation(obs=obs, purpose=purpose)
+
+    # Verify that the calculation succeeds
+    assert result.success is True
+    assert result.job_id == 1
+    assert len(result.metric_results) == 2
+
+    # Verify job was created with correct observation_id
+    executed_job = JobHandler(engine).get(1)
+    assert executed_job.status == JobStatus.COMPLETED
+    assert executed_job.observation_id == expected_obs_id
+
+
+@pytest.mark.parametrize(
+    "obs_factory,expected_obs_id_in_message,error_type,expected_error_message",
+    [
+        (
+            lambda: ObservationDTO(
+                id=None,
+                experiment_id=None,
+                name="Test",
+                db_experiment_name="test",
+                split_id="user_id",
+                calculation_scenario="base",
+                exposure_start_datetime="2024-01-01",
+                exposure_end_datetime="2024-01-31",
+                calc_start_datetime="2024-01-01",
+                calc_end_datetime="2024-01-31",
+                exposure_event="view",
+                audience_tables=["active_users"],
+                filters=None,
+                custom_test_ids_query=None,
+                _created_at=None,
+                _updated_at=None,
+            ),
+            "None",
+            "job_creation_none",
+            "Could not create job for observation #None",
+        ),
+        (
+            lambda: ObservationDTO(
+                id=99,
+                experiment_id=1,
+                name="Test",
+                db_experiment_name="test",
+                split_id="user_id",
+                calculation_scenario="base",
+                exposure_start_datetime="2024-01-01",
+                exposure_end_datetime="2024-01-31",
+                calc_start_datetime="2024-01-01",
+                calc_end_datetime="2024-01-31",
+                exposure_event="view",
+                audience_tables=["active_users"],
+                filters=None,
+                custom_test_ids_query=None,
+                _created_at=None,
+                _updated_at=None,
+            ),
+            "99",
+            "job_creation_exception",
+            "Job create failed for observation #99: DB connection failed",
+        ),
+    ],
+)
+def test_calculation_runner_job_creation_error_handling(
+    mock_calculation_runner,
+    engine,
+    tables,
+    obs_factory,
+    expected_obs_id_in_message,
+    error_type,
+    expected_error_message,
+):
+    """Test job creation error handling with different observation types and error scenarios."""
+    # Create observation using the factory function
+    obs = obs_factory()
+
+    if error_type == "job_creation_none":
+        mock_patch = patch("src.services.runners.executors.JobHandler.create", return_value=None)
+    else:  # job_creation_exception
+        mock_patch = patch(
+            "src.services.runners.executors.JobHandler.create",
+            side_effect=Exception("DB connection failed"),
+        )
+
+    with mock_patch:
+        result = mock_calculation_runner.run_calculation(obs=obs, purpose=CalculationPurpose.PLANNING)
+
+    assert result.success is False
+    assert result.job_id is None
+    assert expected_error_message in result.error_message


### PR DESCRIPTION
Fix Planner Page Critical Issues

### Overview
This PR resolves critical issues in the experiment planner page that were preventing proper functionality, including template path corrections, type safety improvements, and UI component fixes.

### Key Changes

**Template Path Fixes**
- Fixed incorrect include paths in BigQuery and Snowflake query templates
- Changed from `base_new/` and `base/` to correct `bigquery_example/` and `snowflake_example/` paths
- Ensures query templates can be properly resolved during planning calculations

**Type Safety & Error Handling**
- Enhanced `JobGateway.create_pending()` to handle `None` observation IDs safely
- Improved observation ID type checking in `CalculationRunner` with proper `Column` type handling
- Added comprehensive error handling for job creation failures
- Fixed edge cases where observation IDs could be SQLAlchemy `Column` objects

**Planner Page UI**
- Added missing `calculation_scenario` parameter to planning form inputs
- Refactored calculation scenario selection into reusable `CalculationScenarioSelectBox` component
- Fixed `JobResult` handling in planner page to work with proper domain objects instead of dictionaries
- Improved error messaging and status handling for planning calculations

**Data Loading**
- Updated `get_precomputes_for_planning()` to return proper `JobResult` objects
- Removed deprecated `asdict()` usage in favor of domain object handling
- Added proper null handling for event timestamps in BigQuery user aggregation

**Test Coverage**
- Added comprehensive tests for different observation types (SQLAlchemy models vs DTOs)
- Enhanced test coverage for job creation error scenarios
- Fixed flaky statistical test seeds for consistent CI/CD runs
- Updated planner page tests to match new component structure
