### PR TITLE
Fix analytics edge cases and assistant message filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ alembic*
 .log
 .parquet
 .mypy_cache/
+.zed
+.cursor

--- a/assistant/utils.py
+++ b/assistant/utils.py
@@ -11,8 +11,10 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     ModelResponsePart,
+    SystemPromptPart,
     TextPart,
     ThinkingPart,
+    UserPromptPart,
 )
 from pydantic_ai.usage import RequestUsage
 
@@ -59,7 +61,7 @@ def drop_empty_messages(messages: list[ModelMessage]) -> list[ModelMessage]:
             req_parts = [
                 p
                 for p in msg.parts
-                if getattr(p, "has_content", False) or bool(getattr(p, "content", None))
+                if isinstance(p, UserPromptPart | SystemPromptPart) and bool(getattr(p, "content", None))
             ]
             if req_parts:
                 cleaned.append(ModelRequest(parts=req_parts))

--- a/src/domain/metrics.py
+++ b/src/domain/metrics.py
@@ -20,7 +20,7 @@ INVALID_SQL_KEYWORDS = [
     "DELETE",
     "CREATE",
     "MERGE",
-    "UPDATE",
+    # "UPDATE", # Allow UPDATE in strings
     "JOIN",
     "WHERE",
     "GROUP",
@@ -125,7 +125,7 @@ class UserAggregationFormula(BaseModel):
             )
 
         # check invalid keywords
-        statement_pattern = r"\b(?:" + "|".join(INVALID_SQL_KEYWORDS) + r")\b"
+        statement_pattern = r"\b(" + "|".join(INVALID_SQL_KEYWORDS) + r")\b"
         if re.search(statement_pattern, value, re.IGNORECASE):
             raise ValueError(
                 f"<{value}> SQL expression has invalid keywords {', '.join(INVALID_SQL_KEYWORDS)}."

--- a/src/services/analytics/calculators.py
+++ b/src/services/analytics/calculators.py
@@ -407,7 +407,9 @@ class SampleSizeCalculator:
             else:
                 raise ValueError(f"Unsupported metric type: {metric_result.metric_type}")
 
-            observations_per_day = metric_result.observation_cnt / reference_period_days
+            observations_per_day = (
+                metric_result.observation_cnt / reference_period_days
+            ) / 2  # Assuming 2 groups (A/B)
 
             sample_size_results.append(
                 SampleSizeCalculation(

--- a/src/services/analytics/stat_functions.py
+++ b/src/services/analytics/stat_functions.py
@@ -33,6 +33,7 @@ SRMResult = namedtuple(
     "SRMResult", ["statistic", "p_value", "df", "expected", "observed", "allocation", "is_srm"]
 )
 
+EPS = 1e-9
 
 def ttest_welch(
     mean_1: float | np.ndarray,
@@ -189,15 +190,15 @@ def ratio_metric_sample_variance(
     Args:
         mean_n: Mean of the numerator.
         var_n: Variance of the numerator. Must be non-negative.
-        mean_d: Mean of the denominator. Cannot be zero.
+        mean_d: Mean of the denominator. Can be zero.
         var_d: Variance of the denominator. Must be non-negative.
         cov: Covariance between the numerator and denominator.
 
     Returns:
-        The estimated variance of the ratio metric.
+        The estimated variance of the ratio metric. Returns 0 if mean_d is zero.
 
     Raises:
-        ValueError: If any variance is negative or if mean_d is zero.
+        ValueError: If any variance is negative.
         TypeError: If arguments are not of the same type (all float or all
             np.ndarray).
         ValueError: If np.ndarray arguments have different shapes.
@@ -222,7 +223,17 @@ def ratio_metric_sample_variance(
     np.divide(2 * mean_n * cov, mean_d**3, out=term3, where=mean_ne_zero_mask)
 
     res_var_raw = term1 + term2 - term3
-    res_var = np.where((res_var_raw > -1e-9) & (res_var_raw < 0), 0, res_var_raw)
+    
+    # Mathematically, res_var_raw is Var(X - (E[X]/E[Y])Y) / E[Y]^2, which is always >= 0.
+    # Any negative value is due to floating point precision. We use a relative tolerance.
+    max_term = np.maximum(np.maximum(np.abs(term1), np.abs(term2)), np.abs(term3))
+    tolerance = 1e-9 * max_term + EPS
+    
+    res_var = np.where((res_var_raw >= -tolerance) & (res_var_raw < 0), 0.0, res_var_raw)
+    res_var = np.where(mean_ne_zero_mask, res_var, 0.0)
+
+    if not isinstance(mean_n, np.ndarray) and isinstance(res_var, np.ndarray):
+        return float(res_var)
     return res_var
 
 
@@ -269,15 +280,13 @@ def ratio_metric_test(
     diff_se = np.sqrt(diff_var)
 
     # avoiding division by zero
-    eps = 1e-12
-    is_se_zero = np.isclose(diff_se, 0.0, atol=eps)
-    is_diff_zero = np.isclose(diff_metric, 0.0, atol=eps)
+    is_se_zero = np.isclose(diff_se, 0.0, atol=EPS)
+    is_diff_zero = np.isclose(diff_metric, 0.0, atol=EPS)
 
     z_stat = np.divide(diff_metric, diff_se, out=np.zeros_like(diff_metric, dtype=float), where=~is_se_zero)
     need_inf = is_se_zero & ~is_diff_zero
     if np.any(need_inf):
-        inf_val = np.sign(diff_metric) * np.inf
-        z_stat = np.where(need_inf, inf_val, z_stat)
+        z_stat = np.where(need_inf, np.where(diff_metric > 0, np.inf, -np.inf), z_stat)
 
     p_value = 2 * (1 - norm.cdf(abs(z_stat)))
 
@@ -287,8 +296,8 @@ def ratio_metric_test(
 
     diff_ratio = np.empty_like(diff_metric, dtype=float)
 
-    m1_zero = np.isclose(metric_value_1, 0.0, atol=eps)
-    diff_zero = np.isclose(diff_metric, 0.0, atol=eps)
+    m1_zero = np.isclose(metric_value_1, 0.0, atol=EPS)
+    diff_zero = np.isclose(diff_metric, 0.0, atol=EPS)
 
     np.divide(diff_metric, metric_value_1, out=diff_ratio, where=~m1_zero)
 
@@ -298,8 +307,7 @@ def ratio_metric_test(
     # zero baseline and non-zero difference -> ±inf (without inf*0, because mask excludes diff==0)
     mask_inf = m1_zero & ~diff_zero
     if np.any(mask_inf):
-        inf_val = np.sign(diff_metric) * np.inf
-        diff_ratio = np.where(mask_inf, inf_val, diff_ratio)
+        diff_ratio = np.where(mask_inf, np.where(diff_metric > 0, np.inf, -np.inf), diff_ratio)
 
     return TestResult(
         statistic=z_stat,
@@ -356,8 +364,7 @@ def delta_test_ratio_metric(
         - diff_ratio: The relative difference between metrics.
 
     Raises:
-        ValueError: If variances are negative, sample sizes are not positive,
-            or denominator means are zero.
+        ValueError: If variances are negative or sample sizes are not positive.
         TypeError: If arguments are not of the same type.
         ValueError: If np.ndarray arguments have different shapes.
     """

--- a/tests/assistant/test_utils.py
+++ b/tests/assistant/test_utils.py
@@ -1,0 +1,69 @@
+"""Tests for assistant utilities."""
+
+from __future__ import annotations
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from assistant.utils import drop_empty_messages
+
+
+def test_drop_empty_messages_removes_tool_messages():
+    """Tool calls and tool results should be stripped from shared history."""
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="Hello")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="retrieve_internal_db",
+                    args={"query": "SELECT 1"},
+                    tool_call_id="call_1",
+                ),
+                TextPart(content="Let me check the database."),
+            ]
+        ),
+        ModelRequest(
+            parts=[ToolReturnPart(tool_name="retrieve_internal_db", content="42", tool_call_id="call_1")]
+        ),
+        ModelResponse(parts=[TextPart(content="The answer is 42.")]),
+    ]
+
+    cleaned = drop_empty_messages(messages)
+
+    assert len(cleaned) == 3
+    assert isinstance(cleaned[0], ModelRequest)
+    assert isinstance(cleaned[0].parts[0], UserPromptPart)
+    assert cleaned[0].parts[0].content == "Hello"
+
+    assert isinstance(cleaned[1], ModelResponse)
+    assert cleaned[1].parts == [TextPart(content="Let me check the database.")]
+
+    assert isinstance(cleaned[2], ModelResponse)
+    assert cleaned[2].parts == [TextPart(content="The answer is 42.")]
+
+
+def test_drop_empty_messages_keeps_only_textual_turns():
+    """Only user prompts and assistant text survive; everything else is dropped."""
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="What is Expanto?")]),
+        ModelResponse(parts=[TextPart(content="Expanto is an A/B testing platform.")]),
+        ModelRequest(parts=[ToolReturnPart(tool_name="some_tool", content="data", tool_call_id="x")]),
+    ]
+
+    cleaned = drop_empty_messages(messages)
+
+    assert len(cleaned) == 2
+    assert all(isinstance(m, ModelRequest | ModelResponse) for m in cleaned)
+    assert cleaned[0].parts[0].content == "What is Expanto?"
+    assert cleaned[1].parts[0].content == "Expanto is an A/B testing platform."
+
+
+def test_drop_empty_messages_empty_input():
+    """Empty input returns empty output."""
+    assert drop_empty_messages([]) == []

--- a/tests/services/analytics/stat_functions/test_delta_method.py
+++ b/tests/services/analytics/stat_functions/test_delta_method.py
@@ -174,8 +174,32 @@ def test_ratio_metric_mean_d_zero_no_warnings(recwarn):
         var_d=np.array([5]),
         cov=np.array([2]),
     )
-    assert np.isnan(var)
+    assert var == 0
     assert len(recwarn) == 0
+
+
+def test_delta_test_ratio_metric_mean_d_zero_no_warnings(recwarn):
+    """
+    Test that delta_test_ratio_metric handles mean_d = 0 safely.
+    """
+    test_result = delta_test_ratio_metric(
+        metric_1=np.array([0]),
+        mean_n_1=np.array([50]),
+        var_n_1=np.array([10]),
+        mean_d_1=np.array([0]),
+        var_d_1=np.array([5]),
+        cov_1=np.array([2]),
+        n_1=np.array([100]),
+        metric_2=np.array([0]),
+        mean_n_2=np.array([50]),
+        var_n_2=np.array([10]),
+        mean_d_2=np.array([0]),
+        var_d_2=np.array([5]),
+        cov_2=np.array([2]),
+        n_2=np.array([100]),
+    )
+    assert len(recwarn) == 0
+    assert test_result.p_value == 1.0
 
 
 def test_ratio_metric_test_zero_variances_no_warnings(recwarn):

--- a/tests/services/analytics/test_calculators.py
+++ b/tests/services/analytics/test_calculators.py
@@ -343,7 +343,7 @@ def test_sample_size_calculator_all_metrics_trivial(valid_metric_results):
             f"Sample sizes length mismatch for metric {result.metric_name}"
         )
         assert (
-            result.observations_per_day == valid_metric_results[i].observation_cnt / reference_period_days
+            result.observations_per_day == (valid_metric_results[i].observation_cnt / reference_period_days) / 2
         ), f"Observations per day mismatch for {result.metric_name}"
 
 


### PR DESCRIPTION
Handle zero denominator means in ratio metric variance and delta tests with stable floating-point tolerance. Correct sample-size observations per day for two-group experiments, relax metric SQL keyword validation, and strip tool messages from shared assistant history.